### PR TITLE
Remove unused variables

### DIFF
--- a/classes/Bili/Display.php
+++ b/classes/Bili/Display.php
@@ -42,7 +42,7 @@ class Display
         $arrExec[] = $strOutput;
         $strExec = implode(" ", $arrExec);
 
-        $blnCreated = exec($strExec);
+        exec($strExec);
 
         if (file_exists($strPdfFile)) {
             $varReturn = file_get_contents($strPdfFile);

--- a/classes/Bili/FileIO.php
+++ b/classes/Bili/FileIO.php
@@ -109,7 +109,7 @@ class FileIO
         $arrExec[] = $strOutput;
         $strExec = implode(" ", $arrExec);
 
-        $blnCreated = exec($strExec);
+        exec($strExec);
 
         if (file_exists($strPdfFile)) {
             $varReturn = file_get_contents($strPdfFile);
@@ -162,7 +162,7 @@ class FileIO
         chmod($strCommandFile, 0777);
 
         //*** Execute the bash script.
-        $blnReturn = exec($strCommandFile);
+        exec($strCommandFile);
 
         if (file_exists($strSaveFile) && $blnMove) {
             //*** Move the temp file to the original.


### PR DESCRIPTION
The `$blnCreated` parameters are never used and shouldn’t be defined in the first place as discussed in #4.

Fixes #4