### PR TITLE
Introduced the appendParameters setting

### DIFF
--- a/classes/Bili/Display.php
+++ b/classes/Bili/Display.php
@@ -42,7 +42,7 @@ class Display
         $arrExec[] = $strOutput;
         $strExec = implode(" ", $arrExec);
 
-        $blnCreated = exec($strExec);
+        exec($strExec);
 
         if (file_exists($strPdfFile)) {
             $varReturn = file_get_contents($strPdfFile);

--- a/classes/Bili/FileIO.php
+++ b/classes/Bili/FileIO.php
@@ -109,7 +109,7 @@ class FileIO
         $arrExec[] = $strOutput;
         $strExec = implode(" ", $arrExec);
 
-        $blnCreated = exec($strExec);
+        exec($strExec);
 
         if (file_exists($strPdfFile)) {
             $varReturn = file_get_contents($strPdfFile);
@@ -162,7 +162,7 @@ class FileIO
         chmod($strCommandFile, 0777);
 
         //*** Execute the bash script.
-        $blnReturn = exec($strCommandFile);
+        exec($strCommandFile);
 
         if (file_exists($strSaveFile) && $blnMove) {
             //*** Move the temp file to the original.

--- a/classes/Bili/FileIO.php
+++ b/classes/Bili/FileIO.php
@@ -102,11 +102,22 @@ class FileIO
         //*** Extra parameters.
         $strParameters = (is_array($arrParameters)) ? implode(" ", $arrParameters) : "";
 
+        //*** Append parameters.
+        $strAppendParameters = '';
+        if (isset($arrSettings['appendParameters'])) {
+            if (is_array($arrSettings['appendParameters'])) {
+                $strAppendParameters = implode(' ', $arrSettings['appendParameters']);
+            } else if (is_string($arrSettings['appendParameters'])) {
+                $strAppendParameters = $arrSettings['appendParameters'];
+            }
+        }
+
         $arrExec = array();
         $arrExec[] = $arrSettings["wkhtmltopdfPath"];
         $arrExec[] = $strParameters;
         $arrExec[] = $strInput;
         $arrExec[] = $strOutput;
+        $arrExec[] = $strAppendParameters;
         $strExec = implode(" ", $arrExec);
 
         exec($strExec);


### PR DESCRIPTION
As discussed in #7, this setting allows a user to either append options to the wkhtmltopdf command or define its stdout and stderr output.

The value of $arrSettings[‘appendParameters’] can be both a string and an array.

Closes #8