### PR TITLE
Introduced appendParameter setting

### DIFF
--- a/classes/Bili/FileIO.php
+++ b/classes/Bili/FileIO.php
@@ -102,11 +102,22 @@ class FileIO
         //*** Extra parameters.
         $strParameters = (is_array($arrParameters)) ? implode(" ", $arrParameters) : "";
 
+        //*** Append parameters.
+        $strAppendParameters = '';
+        if (isset($arrSettings['appendParameters'])) {
+            if (is_array($arrSettings['appendParameters'])) {
+                $strAppendParameters = implode(' ', $arrSettings['appendParameters']);
+            } else if (is_string($arrSettings['appendParameters'])) {
+                $strAppendParameters = $arrSettings['appendParameters'];
+            }
+        }
+
         $arrExec = array();
         $arrExec[] = $arrSettings["wkhtmltopdfPath"];
         $arrExec[] = $strParameters;
         $arrExec[] = $strInput;
         $arrExec[] = $strOutput;
+        $arrExec[] = $strAppendParameters;
         $strExec = implode(" ", $arrExec);
 
         exec($strExec);


### PR DESCRIPTION
Append parameters to the wkhtmltopdf command using the `appendParameters` key in the `$arrSettings` array.

The value of `$arrSettings[‘appendParameters’]` can be either a string or an array. Arrays will be concatenated using spaces into a single string.