### PR TITLE
Better handling on failure

### DIFF
--- a/classes/Bili/Date.php
+++ b/classes/Bili/Date.php
@@ -3,6 +3,7 @@
 namespace Bili;
 
 use Carbon\Carbon;
+use Carbon\Exceptions\InvalidFormatException;
 use DateInterval;
 use DateTime;
 use Exception;
@@ -164,7 +165,11 @@ class Date
      */
     public static function parseDate(string $strDate, string $strIsoFormat)
     {
-        $objCarbon = Carbon::createFromIsoFormat($strIsoFormat, $strDate);
+        try {
+            $objCarbon = Carbon::createFromIsoFormat($strIsoFormat, $strDate);
+        } catch (InvalidFormatException $ex) {
+            return false;
+        }
 
         /**
          * If there are only date related formats and no time formats,
@@ -177,7 +182,7 @@ class Date
         $intReturn = $objCarbon->getTimestamp();
 
         //*** Check if reverse result is the same otherwise return false.
-        if ($objCarbon->isoFormat($strIsoFormat) !== $strDate) {
+        if ($objCarbon->locale('en')->isoFormat($strIsoFormat) !== $strDate) {
             $intReturn = false;
         }
 


### PR DESCRIPTION
When the iso format is incorrect the parse date function should return null.

The createFromIsoFormat is only working for the english language so the reverse control should always in english.