### PR TITLE
refactor return type of BubbleMessage::jsonSerialize

### DIFF
--- a/classes/Bili/BubbleMessage.php
+++ b/classes/Bili/BubbleMessage.php
@@ -100,7 +100,7 @@ class BubbleMessage extends ClassDynamic implements \JsonSerializable
         return $this->icon;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             "type" => $this->type,

--- a/classes/Bili/BubbleMessage.php
+++ b/classes/Bili/BubbleMessage.php
@@ -100,7 +100,8 @@ class BubbleMessage extends ClassDynamic implements \JsonSerializable
         return $this->icon;
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return [
             "type" => $this->type,

--- a/classes/Bili/Collection.php
+++ b/classes/Bili/Collection.php
@@ -154,7 +154,8 @@ class Collection implements \Iterator, \JsonSerializable
     /**
      * Get the current item from the collection.
      */
-    public function current(): mixed
+    #[\ReturnTypeWillChange]
+    public function current()
     {
         return current($this->collection);
     }
@@ -195,7 +196,8 @@ class Collection implements \Iterator, \JsonSerializable
     /**
      * Get the current position of the pointer.
      */
-    public function key(): mixed
+    #[\ReturnTypeWillChange]
+    public function key()
     {
         return key($this->collection);
     }
@@ -464,7 +466,8 @@ class Collection implements \Iterator, \JsonSerializable
         return $intReturn;
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->collection;
     }

--- a/classes/Bili/Collection.php
+++ b/classes/Bili/Collection.php
@@ -2,6 +2,8 @@
 
 namespace Bili;
 
+use ReturnTypeWillChange;
+
 class Collection implements \Iterator, \JsonSerializable
 {
     protected $collection = array();
@@ -152,7 +154,7 @@ class Collection implements \Iterator, \JsonSerializable
     /**
      * Get the current item from the collection.
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->collection);
     }
@@ -160,6 +162,7 @@ class Collection implements \Iterator, \JsonSerializable
     /**
      * Place the pointer one item forward and return the item.
      */
+    #[ReturnTypeWillChange]
     public function next()
     {
         return next($this->collection);
@@ -192,7 +195,7 @@ class Collection implements \Iterator, \JsonSerializable
     /**
      * Get the current position of the pointer.
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->collection);
     }
@@ -226,7 +229,7 @@ class Collection implements \Iterator, \JsonSerializable
     /**
      * Test if the requested item is valid.
      */
-    public function valid()
+    public function valid(): bool
     {
         if ($this->pageItems > 0) {
             if ($this->key() + 1 > $this->pageEnd()) {
@@ -242,6 +245,7 @@ class Collection implements \Iterator, \JsonSerializable
     /**
      * Reset the internal pointer of the collection to the first item.
      */
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         if ($this->pageItems > 0) {
@@ -326,7 +330,7 @@ class Collection implements \Iterator, \JsonSerializable
             $intPage = 1;
             $strRewrite    = Request::get('rewrite');
             if (!empty($strRewrite) && mb_strpos($strRewrite, "__page") !== false) {
-                $strRewrite = rtrim($strRewrite, " \/");
+                $strRewrite = rtrim((string)$strRewrite, " \/");
                 $arrParams = explode("/", $strRewrite);
                 $intPage = array_pop($arrParams);
             } else {
@@ -460,7 +464,7 @@ class Collection implements \Iterator, \JsonSerializable
         return $intReturn;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->collection;
     }

--- a/classes/Bili/Crypt.php
+++ b/classes/Bili/Crypt.php
@@ -25,7 +25,7 @@ class Crypt
                 throw new \InvalidArgumentException('Length must be a positive integer');
             }
 
-            $alphaMax = strlen($strChars) - 1;
+            $alphaMax = strlen((string)$strChars) - 1;
             if ($alphaMax < 1) {
                 throw new \InvalidArgumentException('Invalid alphabet');
             }
@@ -44,12 +44,12 @@ class Crypt
             $key = '7398541620';
             $out = "";
 
-            for ($i=0; $i < strlen($in); $i++) {
+            for ($i=0; $i < strlen((string)$in); $i++) {
                 $out .= $key[substr($in, $i, 1)]; // Encode string according to key.
             }
 
-            if (strlen($out) < 7) {
-                $padding = (7 - strlen($out));
+            if (strlen((string)$out) < 7) {
+                $padding = (7 - strlen((string)$out));
                 $out .= substr(($in * 534648), 0, $padding); // Add padding characters.
                 $out .= $padding; // Add number of padding characters.
             } else {
@@ -75,7 +75,7 @@ class Crypt
                 $in = substr($in, 0, -1); // Remove the padding.
             }
 
-            for ($i=0; $i<strlen($in); $i++) {
+            for ($i=0; $i<strlen((string)$in); $i++) {
                 $out .= strpos($key, $in[$i]); // Decode string according to key.
             }
 

--- a/classes/Bili/Date.php
+++ b/classes/Bili/Date.php
@@ -266,7 +266,7 @@ class Date
         $strDelimiter = static::getDateDelimiter($strDate);
 
         if (is_null($strDelimiter)) {
-            if (strlen($strDate) < 8) {
+            if (strlen((string)$strDate) < 8) {
                 $strNewDate = "";
                 $arrDate = str_split($strDate, 2);
 
@@ -281,7 +281,7 @@ class Date
                 $strReturn = $strNewDate;
             }
         } else {
-            if (strlen($strDate) < 10) {
+            if (strlen((string)$strDate) < 10) {
                 $arrNewDate = [];
                 $arrDate = explode($strDelimiter, $strDate);
 

--- a/classes/Bili/Display.php
+++ b/classes/Bili/Display.php
@@ -203,12 +203,12 @@ class Display
 
         $strReturn = substr($strValue, 0, $intCharLength);
 
-        if ($blnPreserveWord == true && strlen($strReturn) < strlen($strValue)) {
+        if ($blnPreserveWord == true && strlen((string)$strReturn) < strlen((string)$strValue)) {
             $intLastSpace = strrpos($strReturn, " ");
             $strReturn = substr($strReturn, 0, $intLastSpace);
         }
 
-        if (strlen($strReturn) < strlen($strValue)) {
+        if (strlen((string)$strReturn) < strlen((string)$strValue)) {
             $strReturn .= $strAppend;
         }
 
@@ -242,7 +242,7 @@ class Display
      */
     public static function filterForJavascript($text, $strAllowedTags = "<a>")
     {
-        $text = trim($text);
+        $text = trim((string)$text);
         $text = strip_tags($text, $strAllowedTags);
         $text = json_encode($text);
 

--- a/classes/Bili/FTP.php
+++ b/classes/Bili/FTP.php
@@ -301,22 +301,22 @@ class FTP
 
         if (stristr($strWildcard, "*") !== false) {
             if (strpos($strWildcard, "*") === 0) {
-                if (strrpos($strWildcard, "*") === (strlen($strWildcard) - 1)) {
+                if (strrpos($strWildcard, "*") === (strlen((string)$strWildcard) - 1)) {
                     //*** Wildcard at start and end.
-                    $strNoWildcard = substr(substr($strWildcard, 0, (strlen($strWildcard) - 1)), 1);
+                    $strNoWildcard = substr(substr($strWildcard, 0, (strlen((string)$strWildcard) - 1)), 1);
                     if (strpos($strName, $strNoWildcard) !== false) {
                         $blnReturn = true;
                     }
                 } else {
                     //*** Wildcard at start.
                     $strNoWildcard = substr($strWildcard, 1);
-                    if (strpos($strName, $strNoWildcard) === strlen($strName) - strlen($strNoWildcard)) {
+                    if (strpos($strName, $strNoWildcard) === strlen((string)$strName) - strlen((string)$strNoWildcard)) {
                         $blnReturn = true;
                     }
                 }
-            } elseif (strpos($strWildcard, "*") === (strlen($strWildcard) - 1)) {
+            } elseif (strpos($strWildcard, "*") === (strlen((string)$strWildcard) - 1)) {
                 //*** Wildcard at end.
-                $strNoWildcard = substr($strWildcard, 0, (strlen($strWildcard) - 1));
+                $strNoWildcard = substr($strWildcard, 0, (strlen((string)$strWildcard) - 1));
                 if (strpos($strName, $strNoWildcard) === 0) {
                     $blnReturn = true;
                 }

--- a/classes/Bili/FileIO.php
+++ b/classes/Bili/FileIO.php
@@ -222,7 +222,7 @@ class FileIO
 
         // Clean the fileName for security reasons
         $originalName = $fileName;
-        $fileName = filter_var($fileName, FILTER_SANITIZE_STRING);
+        $fileName = Sanitize::filterStringPolyfill($fileName);
         $fileName = str_replace(" ", "-", $fileName);
         $fileName = str_replace("---", "-", $fileName);
         $fileName = str_replace("--", "-", $fileName);

--- a/classes/Bili/Request.php
+++ b/classes/Bili/Request.php
@@ -117,7 +117,7 @@ class Request
 
     public static function getSubURI()
     {
-        return (strlen(dirname($_SERVER['PHP_SELF'])) > 1) ?
+        return (strlen((string)dirname($_SERVER['PHP_SELF'])) > 1) ?
             dirname($_SERVER['PHP_SELF']) : substr(dirname($_SERVER['PHP_SELF']), 0, -1);
     }
 

--- a/classes/Bili/Response.php
+++ b/classes/Bili/Response.php
@@ -161,7 +161,7 @@ class Response
                 //*** Skip detection.
             }
 
-            self::pushDownloadHeadersToBrowser($mimeType, $strFilename, strlen($strFileData));
+            self::pushDownloadHeadersToBrowser($mimeType, $strFilename, strlen((string)$strFileData));
 
             echo $strFileData;
         } else {
@@ -200,7 +200,7 @@ class Response
                 //*** Skip detection.
             }
 
-            self::pushFileHeadersToBrowser($mimeType, strlen($binFileData));
+            self::pushFileHeadersToBrowser($mimeType, strlen((string)$binFileData));
 
             echo $binFileData;
         } else {

--- a/classes/Bili/RestRequest.php
+++ b/classes/Bili/RestRequest.php
@@ -139,7 +139,7 @@ class RestRequest
             $this->buildPostBody();
         }
 
-        $this->requestLength = strlen($this->requestBody);
+        $this->requestLength = strlen((string)$this->requestBody);
 
         $fh = fopen("php://memory", "rw");
         fwrite($fh, $this->requestBody);

--- a/classes/Bili/Rewrite.php
+++ b/classes/Bili/Rewrite.php
@@ -348,7 +348,7 @@ class Rewrite
         $strRewrite    = Request::get('rewrite');
 
         if (!empty($strRewrite)) {
-            $strRewrite = rtrim($strRewrite, " \/");
+            $strRewrite = rtrim((string)$strRewrite, " \/");
 
             $blnHasSubsection = false;
             $arrUrl = explode("/", $strRewrite);

--- a/classes/Bili/Sanitize.php
+++ b/classes/Bili/Sanitize.php
@@ -131,11 +131,11 @@ class Sanitize
     {
         $varReturn = 0;
 
-        if (strpos($varInput, ".") < strpos($varInput, ",")) {
-            $varInput = str_replace(".", "", $varInput);
+        if (strpos((string) $varInput, ".") < strpos((string) $varInput, ",")) {
+            $varInput = str_replace(".", "", (string) $varInput);
             $varInput = strtr($varInput, ",", ".");
         } else {
-            $varInput = str_replace(",", "", $varInput);
+            $varInput = str_replace(",", "", (string) $varInput);
         }
 
         $varReturn = (float) $varInput;

--- a/classes/Bili/Sanitize.php
+++ b/classes/Bili/Sanitize.php
@@ -103,7 +103,7 @@ class Sanitize
 
         $intBase = (int) $fltReturn;
 
-        if (strlen($intBase) > $intMaxLength) {
+        if (strlen((string)$intBase) > $intMaxLength) {
             $fltReturn = (1 * pow(10, $intMaxLength)) - 1;
         }
 
@@ -143,7 +143,7 @@ class Sanitize
         // If the conversion isn't forced we check for specific cases.
         if (!$blnForceConversion) {
             //*** If the return value is 0 and the input was longer we return the input value.
-            if ($varReturn === 0.0 && strlen($varInput) > 1) {
+            if ($varReturn === 0.0 && strlen((string)$varInput) > 1) {
                 $varReturn = $varInput;
             }
 
@@ -210,7 +210,7 @@ class Sanitize
         $strReturn = iconv('UTF-8', 'ASCII//TRANSLIT', $strReturn);
 
         //*** Convert to lower case, trim and replace spaces with dashes.
-        $strReturn = str_replace(' ', '-', trim(strtolower($strReturn)));
+        $strReturn = str_replace(' ', '-', trim((string)strtolower($strReturn)));
 
         //*** Remove anything that isn't a regular character or number.
         $strReturn = preg_replace('/[^\w\s\d\-]/', '', $strReturn);
@@ -259,7 +259,7 @@ class Sanitize
      */
     public static function toString($varInput)
     {
-        $strReturn = filter_var(trim($varInput), FILTER_SANITIZE_STRING);
+        $strReturn = filter_var(trim((string)$varInput), FILTER_SANITIZE_STRING);
 
         return $strReturn;
     }
@@ -282,8 +282,12 @@ class Sanitize
         return $strReturn;
     }
 
-    private static function filterAmpersandEntity(&$text)
+    private static function filterAmpersandEntity(&$text): void
     {
+        if (is_null($text)) {
+            $text = "";
+        }
+
         $text = preg_replace('/&(?!#?[xX]?(?:[0-9a-fA-F]+|\w{1,8});)/i', "&amp;", $text);
     }
 

--- a/classes/Bili/Sanitize.php
+++ b/classes/Bili/Sanitize.php
@@ -259,7 +259,7 @@ class Sanitize
      */
     public static function toString($varInput)
     {
-        $strReturn = filter_var(trim((string)$varInput), FILTER_SANITIZE_STRING);
+        $strReturn = htmlspecialchars(trim((string)$varInput));
 
         return $strReturn;
     }
@@ -300,5 +300,18 @@ class Sanitize
     {
         $text = str_ireplace("target=\"_blank\"", "rel=\"external\"", $text);
         $text = str_ireplace("target=\"_top\"", "rel=\"external\"", $text);
+    }
+
+    /**
+     * Replacement for the FILTER_SANITIZE_STRING which is deprecated in PHP 8.1.
+     * source https://stackoverflow.com/questions/69207368/constant-filter-sanitize-string-is-deprecated
+     *
+     * @param string $string
+     * @return string
+     */
+    public static function filterStringPolyfill(string $string): string
+    {
+        $str = preg_replace('/\x00|<[^>]*>?/', '', $string);
+        return str_replace(["'", '"'], ['&#39;', '&#34;'], $str);
     }
 }

--- a/classes/Bili/SessionManager.php
+++ b/classes/Bili/SessionManager.php
@@ -250,7 +250,7 @@ class SessionManager
     {
         $return_data = array();
         $offset = 0;
-        while ($offset < strlen($session_data)) {
+        while ($offset < strlen((string)$session_data)) {
             if (!strstr(substr($session_data, $offset), "|")) {
                 throw new \Exception("invalid data, remaining: " . substr($session_data, $offset));
             }
@@ -260,7 +260,7 @@ class SessionManager
             $offset += $num + 1;
             $data = unserialize(substr($session_data, $offset));
             $return_data[$varname] = $data;
-            $offset += strlen(serialize($data));
+            $offset += strlen((string)serialize($data));
         }
         return $return_data;
     }
@@ -269,14 +269,14 @@ class SessionManager
     {
         $return_data = array();
         $offset = 0;
-        while ($offset < strlen($session_data)) {
+        while ($offset < strlen((string)$session_data)) {
             $num = ord($session_data[$offset]);
             $offset += 1;
             $varname = substr($session_data, $offset, $num);
             $offset += $num;
             $data = unserialize(substr($session_data, $offset));
             $return_data[$varname] = $data;
-            $offset += strlen(serialize($data));
+            $offset += strlen((string)serialize($data));
         }
         return $return_data;
     }

--- a/tests/CryptTest.php
+++ b/tests/CryptTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Bili\Tests;
+
+use Bili\Crypt;
+use PHPUnit\Framework\TestCase;
+
+class CryptTest extends TestCase
+{
+    /**
+     * Tests Crypt::generateToken default length.
+     *
+     * @return void
+     */
+    public function testGenerateToken(): void
+    {
+        $this->assertEquals(40, strlen((string)Crypt::generateToken()));
+    }
+
+    /**
+     * Tests Crypt::generateToken 32 length.
+     *
+     * @return void
+     */
+    public function testGenerateTokenLength32(): void
+    {
+        $this->assertEquals(32, strlen((string)Crypt::generateToken([], 32)));
+    }
+
+    /**
+     * Tests Crypt::generateToken sha1 encrypt first x chars.
+     *
+     * @return void
+     */
+    public function testGenerateTokenSha1(): void
+    {
+        $this->assertEquals("86f7e437faa5a7fc", Crypt::generateToken(['a'], 16));
+        $this->assertEquals("641e83ce499913cb", Crypt::generateToken(['celery'], 16));
+        $this->assertEquals("4de4727ba00457f7", Crypt::generateToken(['payroll'], 16));
+        $this->assertEquals("2dbc2fd2358e1ea1", Crypt::generateToken(['online'], 16));
+        $this->assertEquals("7b0e4e1f57", Crypt::generateToken(['ea504d83c6'], 10));
+        $this->assertEquals("eb95c067b0", Crypt::generateToken(['5068a9c245'], 10));
+        $this->assertEquals("20929cba0c", Crypt::generateToken(['656228147d'], 10));
+    }
+
+    /**
+     * Tests Crypt::doEncode encode 1.
+     *
+     * @return void
+     */
+    public function testDoEncode1(): void
+    {
+        $this->assertEquals("35346486", Crypt::doEncode(1));
+    }
+
+    /**
+     * Tests Crypt::doEncode encode 2.
+     *
+     * @return void
+     */
+    public function testDoEncode2(): void
+    {
+        $this->assertEquals("91069296", Crypt::doEncode(2));
+    }
+
+    /**
+     * Tests Crypt::doDecode encode 1.
+     *
+     * @return void
+     */
+    public function testDoDecode1(): void
+    {
+        $this->assertEquals(1, Crypt::doDecode("35346486"));
+    }
+
+    /**
+     * Tests Crypt::doDecode encode 2.
+     *
+     * @return void
+     */
+    public function testDoDecode2(): void
+    {
+        $this->assertEquals(2, Crypt::doDecode("91069296"));
+    }
+
+    /**
+     * Tests Crypt::doDecode and Crypt::doEncode.
+     *
+     * @return void
+     */
+    public function testEncodeDecode(): void
+    {
+        for ($i=99; $i<399; $i++) {
+            $this->assertEquals($i, Crypt::doDecode(Crypt::doEncode($i)));
+        }
+    }
+}

--- a/tests/LanguageTest.php
+++ b/tests/LanguageTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Bili\Tests;
+
+use Bili\Language;
+use Bili\LanguageCollection;
+use PHPUnit\Framework\TestCase;
+
+class LanguageTest extends TestCase
+{
+    public const EN = "english-utf-8";
+    public const NL = "nederlands-utf-8";
+
+    /**
+     * Tests getInstance.
+     *
+     * @return void
+     */
+    public function testGetInstance(): void
+    {
+        $objLanguage = Language::getInstance();
+        $this->assertInstanceOf(Language::class, $objLanguage);
+    }
+
+    /**
+     * Tests set lang.
+     *
+     * @return void
+     */
+    public function testSetLangNL(): void
+    {
+        $objLanguage = Language::getInstance();
+        $objLanguage->setLang(self::NL);
+        $this->assertEquals(self::NL, $objLanguage->getActiveLang());
+    }
+
+    /**
+     * Tests set lang.
+     *
+     * @return void
+     */
+    public function testSetLangEN(): void
+    {
+        $objLanguage = Language::getInstance();
+        $objLanguage->setLang(self::EN);
+        $this->assertEquals(self::EN, $objLanguage->getActiveLang());
+    }
+
+    /**
+     * Tests get active language.
+     *
+     * @return void
+     */
+    public function testGetActiveLang(): void
+    {
+        $objLanguage = Language::getInstance();
+        $this->assertEquals(self::EN, $objLanguage->getActiveLang());
+    }
+
+    /**
+     * Tests get translation in English.
+     *
+     * @return void
+     */
+    public function testGetEn(): void
+    {
+        Language::getInstance()->setLang(self::EN);
+        $this->assertEquals("en", Language::get('abbr'));
+        $this->assertEquals("Yes", Language::get('yes', 'message'));
+    }
+
+    /**
+     * Tests get translation in Dutch.
+     *
+     * @return void
+     */
+    public function testGetNl(): void
+    {
+        Language::getInstance()->setLang(self::NL);
+        $this->assertEquals("nl", Language::get('abbr'));
+        $this->assertEquals("Ja", Language::get('yes', 'message'));
+    }
+
+    /**
+     * Tests get translation in Dutch.
+     *
+     * @return void
+     */
+    public function testGetLangs(): void
+    {
+        $this->assertInstanceOf(LanguageCollection::class, Language::getInstance()->getLangs());
+
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        setlocale(LC_ALL, 'en_US.UTF-8');
+        $objLanguage = Language::singleton("english-utf-8", __DIR__ . '/languages/');
+        $objLanguage->setLocale();
+    }
+}

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Bili\Tests;
+
+use Bili\Sanitize;
+use PHPUnit\Framework\TestCase;
+
+class SanitizeTest extends TestCase
+{
+
+
+    public function testToXhtml(): void
+    {
+        $this->assertEquals("M&amp;M's", Sanitize::toXhtml("M&M's"));
+        $this->assertEquals("Ben &amp; Jerry's", Sanitize::toXhtml("Ben & Jerry's"));
+        $this->assertEquals("10&#36; bill", Sanitize::toXhtml("10$ bill"));
+    }
+
+    public function testToEntities(): void
+    {
+        $this->assertEquals("M&amp;M&#039;s", Sanitize::toEntities("M&M's"));
+        $this->assertEquals("Ben &amp; Jerry&#039;s", Sanitize::toEntities("Ben & Jerry's"));
+        $this->assertEquals("10$ bill", Sanitize::toEntities("10$ bill"));
+    }
+
+    public function testFromEntities(): void
+    {
+        $this->assertEquals("M&M's", Sanitize::fromEntities("M&amp;M&#039;s"));
+        $this->assertEquals("Ben & Jerry's", Sanitize::fromEntities("Ben &amp; Jerry&#039;s"));
+        $this->assertEquals("10$ bill", Sanitize::fromEntities("10$ bill"));
+    }
+
+    public function testToXml(): void
+    {
+        $this->assertEquals("M&amp;M's", Sanitize::toXml("M&M's"));
+        $this->assertEquals("Ben &amp; Jerry's", Sanitize::toXml("Ben & Jerry's"));
+        $this->assertEquals("10&#36; bill", Sanitize::toXml("10$ bill"));
+    }
+
+    public function testFloatToMaxLength(): void
+    {
+        $this->assertEquals(99999999, Sanitize::floatToMaxLength(234234234.23234234, 8));
+        $this->assertEquals(99348871.343434, Sanitize::floatToMaxLength(99348871.3434344, 9));
+    }
+
+    public function testToDecimal(): void
+    {
+        $this->assertEquals(23.0, Sanitize::toDecimal(23));
+        $this->assertEquals(23.0, Sanitize::toDecimal("23"));
+        $this->assertEquals(99348871.343434, Sanitize::toDecimal(99348871.3434344));
+        $this->assertEquals(1541045.45, Sanitize::toDecimal("1.541.045,45"));
+        $this->assertEquals(1541045.45, Sanitize::toDecimal("1,541,045.45"));
+        $this->assertEquals(1541045.45, Sanitize::toDecimal("1541045,45"));
+        $this->assertEquals(1541045.45, Sanitize::toDecimal("1541045.45"));
+    }
+
+    public function testBr2nl(): void
+    {
+        $this->assertEquals("line\n", Sanitize::br2nl("line<br>"));
+        $this->assertEquals("line\nline\nline\n", Sanitize::br2nl("line<br>line<br>line<br>"));
+    }
+
+    public function testToInteger(): void
+    {
+        $this->assertEquals(1010, Sanitize::toInteger("1010"));
+        $this->assertEquals(1010, Sanitize::toInteger("1010.0"));
+        $this->assertEquals(10, Sanitize::toInteger("10,95"));
+    }
+
+    public function testToUrl(): void
+    {
+        $this->assertEquals("xmonl-testfile-with-long-name", Sanitize::toUrl("xmo.nl /test/file with long name"));
+        $this->assertEquals("mm-testfile-with-long-name", Sanitize::toUrl("m&m /test/file with long name"));
+    }
+
+    public function testToNumeric(): void
+    {
+        $this->assertEquals(0, Sanitize::toNumeric("xml"));
+        $this->assertEquals(10.1, Sanitize::toNumeric(10.10));
+    }
+
+    public function testToString(): void
+    {
+        $this->assertSame('xml', Sanitize::toString("xml"));
+        $this->assertSame('10.1', Sanitize::toString(10.10));
+    }
+
+    public function testToAscii(): void
+    {
+        $this->assertSame("This is the Euro symbol 'EUR'.", Sanitize::toAscii("This is the Euro symbol '€'."));
+    }
+}

--- a/tests/languages/english-utf-8.php
+++ b/tests/languages/english-utf-8.php
@@ -1,0 +1,9 @@
+<?php
+$_LANG = [
+    'global' => [
+        'abbr' => 'en',
+    ],
+    'message' => [
+        'yes' => 'Yes',
+    ]
+];

--- a/tests/languages/nederlands-utf-8.php
+++ b/tests/languages/nederlands-utf-8.php
@@ -1,0 +1,9 @@
+<?php
+$_LANG = [
+    'global' => [
+        'abbr' => 'nl',
+    ],
+    'message' => [
+        'yes' => 'Ja',
+    ]
+];


### PR DESCRIPTION
Fixes different deprecated messages.

For example:
BubbleMessage::jsonSerialize gives deprecated message.

Return type of Bili\BubbleMessage::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice.
