### PR TITLE
Rollback the toDecimal function to original.

### DIFF
--- a/classes/Bili/Display.php
+++ b/classes/Bili/Display.php
@@ -145,7 +145,7 @@ class Display
      *
      * @param integer $intFrom
      * @param string $strTargetUnit
-     * @return decimal
+     * @return float
      */
     public static function renderBytes($intFrom, $strTargetUnit, $strSourceUnit = "B")
     {

--- a/classes/Bili/Sanitize.php
+++ b/classes/Bili/Sanitize.php
@@ -129,7 +129,16 @@ class Sanitize
      */
     public static function toDecimal(mixed $varInput, bool $blnForceConversion = true): mixed
     {
-        $varReturn = static::toFloat($varInput);
+        $varReturn = 0;
+
+        if (strpos((string) $varInput, ".") < strpos((string) $varInput, ",")) {
+            $varInput = str_replace(".", "", (string) $varInput);
+            $varInput = strtr($varInput, ",", ".");
+        } else {
+            $varInput = str_replace(",", "", (string) $varInput);
+        }
+
+        $varReturn = (float) $varInput;
 
         // If the conversion isn't forced we check for specific cases.
         if (!$blnForceConversion) {

--- a/classes/Bili/Sanitize.php
+++ b/classes/Bili/Sanitize.php
@@ -183,7 +183,7 @@ class Sanitize
     /**
      * Sanitize input to be an integer. Works on single values and arrays.
      *
-     * @param  string|decimal|array $varInput
+     * @param  string|float|array $varInput
      * @param  boolean $blnDiscardInvalid Indicate if the input array should be compacted, leaving out invalid values.
      * @return null|integer
      */
@@ -240,7 +240,7 @@ class Sanitize
      * Sanitize input to be a numeric value. Works on single values and arrays.
      * This will retain leading zeros.
      *
-     * @param  string|decimal|array $varInput
+     * @param  string|float|array $varInput
      * @param  boolean $blnDiscardInvalid Indicate if the input array should be compacted, leaving out invalid values.
      * @return null|float|integer
      */


### PR DESCRIPTION
## Description
Rollback the toDecimal function to original.
The toFloat function inside the toDecimal was to strict, it did not accept mixed.
also replaced the decimal return type with float.

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
- [x] My code follows the code style of this project.
- [x] I have ran all tests and none have failed.
- [x] I have rebased the `develop` branch onto this branch (feature or hotfix).