### PR TITLE
Replaced variable declaration because of deprecation..

### DIFF
--- a/classes/Bili/Date.php
+++ b/classes/Bili/Date.php
@@ -371,7 +371,7 @@ class Date
         );
 
         foreach (array_keys($diffs) as $interval) {
-            while ($strDate2 >= ($t3 = strtotime("+1 ${interval}", $strDate1))) {
+            while ($strDate2 >= ($t3 = strtotime("+1 {$interval}", $strDate1))) {
                 $strDate1 = $t3;
                 ++$diffs[$interval];
             }


### PR DESCRIPTION
Deprecated: Using ${var} in strings is deprecated, use {$var} instead

https://www.php.net/manual/en/migration82.deprecated.php