### PR TITLE
Update `nesbot/carbon` Dependency to Support Version 3.x

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.3, 8.2, 8.1]
+        php: [8.4, 8.3, 8.2, 8.1]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/classes/Bili/Date.php
+++ b/classes/Bili/Date.php
@@ -371,7 +371,7 @@ class Date
         );
 
         foreach (array_keys($diffs) as $interval) {
-            while ($strDate2 >= ($t3 = strtotime("+1 ${interval}", $strDate1))) {
+            while ($strDate2 >= ($t3 = strtotime("+1 {$interval}", $strDate1))) {
                 $strDate1 = $t3;
                 ++$diffs[$interval];
             }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-bcmath": "*",
         "mrclay/minify": "3.*",
         "pear/cache_lite": "1.*",
-        "nesbot/carbon": "^2.62.1"
+        "nesbot/carbon": "^2.62.1|^3.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"


### PR DESCRIPTION
## Description

This pull request updates the `composer.json` file to allow compatibility with both `nesbot/carbon` version higher than `2.62.1` and higher than `3.2`. This ensures flexibility for projects that may require the newer version of Carbon while maintaining backward compatibility.

### Changes:
- Updated `"nesbot/carbon": "^2.62.1"`  
  ➝ to `"nesbot/carbon": "^2.62.1|^3.2"` in `composer.json`

## Motivation
- Enables usage of Carbon `3.x`
- Retains compatibility with the existing `2.x` version to avoid breaking changes for projects relying on it.  

 


