### PR TITLE
Sanitize document upload filenames against command injection

### DIFF
--- a/classes/Bili/FileIO.php
+++ b/classes/Bili/FileIO.php
@@ -256,7 +256,7 @@ class FileIO
 
         // Clean the fileName for security reasons
         $originalName = $fileName;
-        $fileName = Sanitize::filterStringPolyfill($fileName);
+        $fileName = Sanitize::filterFilename($fileName);
         $fileName = str_replace(" ", "-", $fileName);
         $fileName = str_replace("---", "-", $fileName);
         $fileName = str_replace("--", "-", $fileName);

--- a/classes/Bili/Sanitize.php
+++ b/classes/Bili/Sanitize.php
@@ -368,4 +368,32 @@ class Sanitize
 
         return str_replace(["'", '"'], ['&#39;', '&#34;'], $str);
     }
+
+    /**
+     * Sanitize a string for safe use as a filename.
+     *
+     * Strips null bytes, HTML tags and shell metacharacters that allow command
+     * substitution or chaining when the filename is later interpolated into a
+     * shell command (e.g. for preview generation). Quote characters are stripped
+     * rather than HTML-encoded, because encoding would introduce `&` and `;`
+     * which are themselves shell metacharacters.
+     *
+     * Defense-in-depth — callers MUST still escape filename arguments with
+     * escapeshellarg() before passing them to exec()/shell_exec()/system().
+     *
+     * @param string|null $string
+     * @return string
+     */
+    public static function filterFilename(?string $string): string
+    {
+        if (is_null($string)) {
+            return "";
+        }
+
+        //*** Strip null bytes and HTML tags (parity with filterStringPolyfill).
+        $str = preg_replace('/\x00|<[^>]*>?/', '', $string);
+
+        //*** Strip shell metacharacters, quotes, backslash and newlines.
+        return preg_replace('/[$`|;&!(){}\[\]\'"\\\\\r\n]/', '', $str);
+    }
 }

--- a/tests/SanitizeTest.php
+++ b/tests/SanitizeTest.php
@@ -136,4 +136,67 @@ class SanitizeTest extends TestCase
         $varInput = "Bon aña 2023, !@#5^&*<>$";
         $this->assertSame("Bon aña 2023, !@#5^&*$", Sanitize::filterStringPolyfill($varInput));
     }
+
+    /**
+     * Sanitize a filename so it is safe to interpolate into a shell command.
+     *
+     * filterFilename() must:
+     *  - return an empty string for null input
+     *  - strip null bytes and HTML tags (parity with filterStringPolyfill())
+     *  - strip shell metacharacters that allow command substitution / chaining when
+     *    the filename is later passed to exec() (e.g. `$()`, backticks, |, ;, &)
+     *  - leave benign filename characters (letters, digits, dot, dash, underscore,
+     *    spaces, accented characters) untouched so that legitimate uploads keep
+     *    their human-readable names.
+     */
+    public function testFilterFilenameReturnsEmptyStringForNull(): void
+    {
+        $this->assertSame("", Sanitize::filterFilename(null));
+    }
+
+    public function testFilterFilenameLeavesBenignFilenameUntouched(): void
+    {
+        $this->assertSame("report.pdf", Sanitize::filterFilename("report.pdf"));
+        $this->assertSame("My Report 2025.pdf", Sanitize::filterFilename("My Report 2025.pdf"));
+        $this->assertSame("año-2025_v1.pdf", Sanitize::filterFilename("año-2025_v1.pdf"));
+    }
+
+    public function testFilterFilenameStripsHtmlTagsAndNullBytes(): void
+    {
+        $this->assertSame("clean.pdf", Sanitize::filterFilename("<script>clean.pdf"));
+        $this->assertSame("clean.pdf", Sanitize::filterFilename("clean\x00.pdf"));
+    }
+
+    public function testFilterFilenameStripsCommandSubstitutionMetacharacters(): void
+    {
+        //*** $() command substitution must not survive into the filename.
+        $this->assertSame("pocwhoami.pdf", Sanitize::filterFilename("poc\$(whoami).pdf"));
+
+        //*** Backtick command substitution must also be stripped.
+        $this->assertSame("pocwhoami.pdf", Sanitize::filterFilename("poc`whoami`.pdf"));
+    }
+
+    public function testFilterFilenameStripsShellChainingMetacharacters(): void
+    {
+        $this->assertSame("aabbc.pdf", Sanitize::filterFilename("a;a|b&b!c.pdf"));
+    }
+
+    public function testFilterFilenameStripsBracesParensAndBrackets(): void
+    {
+        $this->assertSame("abcd.pdf", Sanitize::filterFilename("a(b)c{d}.pdf"));
+        $this->assertSame("abcd.pdf", Sanitize::filterFilename("a[b]c[d].pdf"));
+    }
+
+    public function testFilterFilenameStripsQuotesAndBackslash(): void
+    {
+        //*** Single and double quotes are stripped (not HTML-encoded — encoding would
+        //*** introduce `&` and `;` which themselves are shell metacharacters).
+        $this->assertSame("abc.pdf", Sanitize::filterFilename("a'b\"c.pdf"));
+        $this->assertSame("abc.pdf", Sanitize::filterFilename("a\\b\\c.pdf"));
+    }
+
+    public function testFilterFilenameStripsNewlineAndCarriageReturn(): void
+    {
+        $this->assertSame("abc.pdf", Sanitize::filterFilename("a\nb\rc.pdf"));
+    }
 }


### PR DESCRIPTION
## Summary

Adds `Sanitize::filterFilename()` — a new helper that strips shell metacharacters (`$`, backtick, `|`, `;`, `&`, `!`, parens, braces, brackets, quotes, backslash, newlines) plus null bytes and HTML tags and switches `FileIO::saveTemporaryFile()` over to it. The previous sanitizer (`filterStringPolyfill`) HTML-encoded quotes but left `$`, backticks, and other shell metacharacters intact, so a filename like `poc$(whoami).pdf` could trigger command substitution if later interpolated into a shell command (e.g. preview generation).

## Motivation and Context

`FileIO::saveTemporaryFile()` accepts an attacker-controlled filename from the upload. Downstream code in consuming projects passes that filename to `exec()`/`shell_exec()` for thumbnailing and similar work.
Because `filterStringPolyfill()` is HTML-focused, it does not strip shell metacharacters — so command substitution survives sanitization. `filterFilename()` strips those characters outright. It is documented explicitly as defense-in-depth: callers MUST still wrap the filename in `escapeshellarg()` at the actual `exec()` boundary.

## How Has This Been Tested

Added 7 unit tests in `tests/SanitizeTest.php`:

- null input → empty string
- benign filenames preserved (incl. spaces and accented characters)
- HTML tags and null bytes stripped
- `$(...)` and backtick command substitution stripped
- shell chaining (`;`, `|`, `&`, `!`) stripped
- braces, parens, brackets stripped
- single quotes, double quotes, backslash stripped
- `\n` and `\r` stripped

Run with: `vendor/bin/phpunit tests/SanitizeTest.php`