### PR TITLE
Add opt-out for cookie and session persistence in Language::setLang

### DIFF
--- a/classes/Bili/Language.php
+++ b/classes/Bili/Language.php
@@ -50,7 +50,7 @@ class Language
      * @param string $langPath
      * @param string|string[]|null $overwritePaths
      */
-    private function __construct($strLang = "", $langPath = "", $overwritePaths = null)
+    protected function __construct($strLang = "", $langPath = "", $overwritePaths = null)
     {
         $this->defaultLang = $strLang;
         $this->langPath = $langPath;
@@ -208,12 +208,20 @@ class Language
     }
 
     /**
+     * Set a specific language and load its file.
+     *
+     * When $blnPersist is true (default) the choice is also written to the
+     * session and a 30-day cookie, preserving the original behavior for
+     * stateful web apps. Pass false in stateless contexts (e.g. a REST API
+     * resolving the language from the Accept-Language header) to load the
+     * language file in-process only, without touching the session or cookie.
+     *
      * @param string $strLang
+     * @param bool $blnPersist
      * @return bool
      */
-    public function setLang($strLang)
+    public function setLang($strLang, $blnPersist = true)
     {
-        //*** Set a specific language and write it to the session and cockie.
         $blnReturn = false;
 
         if ($strLang !== $this->activeLang) {
@@ -223,23 +231,11 @@ class Language
         //*** Check if the language file exists and is different from the current language.
         if (file_exists($this->langPath . "/" . $strLang . ".php")
                 && (count(self::$languages) === 0 || $this->forceReload)) {
-            //*** Write to cookie.
-            try {
-                setcookie(
-                    'language',
-                    $strLang,
-                    time() + 60*60*24*30,
-                    '/',
-                    '',
-                    static::$secureCookie,
-                    true
-                );
-            } catch (\Exception $ex) {
-                //*** Probably "headers already sent" error. Never mind. The cookie is not that important.
+            if ($blnPersist) {
+                //*** Persist the choice to the cookie and the session.
+                $this->writeCookie($strLang);
+                $_SESSION['language'] = $strLang;
             }
-
-            //*** Write to session.
-            $_SESSION['language'] = $strLang;
 
             //*** Load new language file;
             $this->getLang($strLang);
@@ -247,6 +243,30 @@ class Language
         }
 
         return $blnReturn;
+    }
+
+    /**
+     * Write the language cookie. Isolated so stateless callers can skip it and
+     * so it can be observed in tests (the CLI SAPI sends no real headers).
+     *
+     * @param string $strLang
+     * @return void
+     */
+    protected function writeCookie($strLang)
+    {
+        try {
+            setcookie(
+                'language',
+                $strLang,
+                time() + 60*60*24*30,
+                '/',
+                '',
+                static::$secureCookie,
+                true
+            );
+        } catch (\Exception $ex) {
+            //*** Probably "headers already sent" error. Never mind. The cookie is not that important.
+        }
     }
 
     /**

--- a/classes/Bili/Language.php
+++ b/classes/Bili/Language.php
@@ -46,11 +46,14 @@ class Language
     private $forceReload            = false;
 
     /**
+     * Private: instances are created by singleton() or getInstance().
+     * Resolves and loads the language file immediately.
+     *
      * @param string $strLang
      * @param string $langPath
      * @param string|string[]|null $overwritePaths
      */
-    protected function __construct($strLang = "", $langPath = "", $overwritePaths = null)
+    private function __construct($strLang = "", $langPath = "", $overwritePaths = null)
     {
         $this->defaultLang = $strLang;
         $this->langPath = $langPath;
@@ -208,17 +211,13 @@ class Language
     }
 
     /**
-     * Set a specific language and load its file.
-     *
-     * When $blnPersist is true (default) the choice is also written to the
-     * session and a 30-day cookie, preserving the original behavior for
-     * stateful web apps. Pass false in stateless contexts (e.g. a REST API
-     * resolving the language from the Accept-Language header) to load the
-     * language file in-process only, without touching the session or cookie.
+     * Sets a specific language and loads its file, session and cookie included.
+     * Pass $blnPersist = false to load without writing either.
+     * Persists only when the file is loaded.
      *
      * @param string $strLang
      * @param bool $blnPersist
-     * @return bool
+     * @return bool True when the language file was loaded, false when nothing changed.
      */
     public function setLang($strLang, $blnPersist = true)
     {
@@ -246,13 +245,13 @@ class Language
     }
 
     /**
-     * Write the language cookie. Isolated so stateless callers can skip it and
-     * so it can be observed in tests (the CLI SAPI sends no real headers).
+     * Writes the 30-day language cookie, ignoring failures.
+     * A missing cookie falls back to the default language.
      *
      * @param string $strLang
      * @return void
      */
-    protected function writeCookie($strLang)
+    private function writeCookie($strLang)
     {
         try {
             setcookie(
@@ -265,7 +264,8 @@ class Language
                 true
             );
         } catch (\Exception $ex) {
-            //*** Probably "headers already sent" error. Never mind. The cookie is not that important.
+            //*** Only thrown when the host converts warnings to exceptions; plain
+            //*** PHP warns and returns false. The cookie is not worth failing over.
         }
     }
 

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "autoload-dev": {
         "psr-4": {
             "Bili\\Tests\\": "tests/"
-        }
+        },
+        "files": ["tests/Support/setcookie.php"]
     }
 }

--- a/tests/LanguageTest.php
+++ b/tests/LanguageTest.php
@@ -92,6 +92,108 @@ class LanguageTest extends TestCase
 
     }
 
+    /**
+     * setLang() with $blnPersist = false loads the language in-process but must
+     * not write $_SESSION['language'] (stateless API use case, bili#29).
+     *
+     * @return void
+     */
+    public function testSetLangNoPersistDoesNotWriteSession(): void
+    {
+        // Normalize to a known active language, then clear the session so we
+        // only observe writes caused by the switch under test.
+        Language::getInstance()->setLang(self::EN);
+        $_SESSION = [];
+
+        $objLanguage = Language::getInstance();
+        $objLanguage->setLang(self::NL, false);
+
+        $this->assertEquals(self::NL, $objLanguage->getActiveLang());
+        $this->assertArrayNotHasKey('language', $_SESSION);
+    }
+
+    /**
+     * setLang() with $blnPersist = false must still load the language file so
+     * subsequent Language::get() calls return strings in that language.
+     *
+     * @return void
+     */
+    public function testSetLangNoPersistStillLoadsLanguageFile(): void
+    {
+        Language::getInstance()->setLang(self::EN);
+        Language::getInstance()->setLang(self::NL, false);
+
+        $this->assertEquals('nl', Language::get('abbr'));
+        $this->assertEquals('Ja', Language::get('yes', 'message'));
+    }
+
+    /**
+     * The default ($blnPersist = true) preserves today's behavior: the chosen
+     * language is written to $_SESSION['language'].
+     *
+     * @return void
+     */
+    public function testSetLangPersistWritesSession(): void
+    {
+        Language::getInstance()->setLang(self::EN);
+        $_SESSION = [];
+        Language::getInstance()->setLang(self::NL);
+
+        $this->assertEquals(self::NL, $_SESSION['language']);
+    }
+
+    /**
+     * The default ($blnPersist = true) still writes the language cookie.
+     *
+     * @return void
+     */
+    public function testSetLangPersistWritesCookie(): void
+    {
+        $_SESSION = [];
+        $spy = $this->createCookieSpy();
+        $spy->setLang(self::NL);
+
+        $this->assertSame(1, $spy->cookieWrites);
+    }
+
+    /**
+     * setLang() with $blnPersist = false must not write the language cookie.
+     *
+     * @return void
+     */
+    public function testSetLangNoPersistDoesNotWriteCookie(): void
+    {
+        $_SESSION = [];
+        $spy = $this->createCookieSpy();
+        $spy->setLang(self::NL, false);
+
+        $this->assertSame(0, $spy->cookieWrites);
+    }
+
+    /**
+     * A Language subclass that records cookie writes instead of sending a real
+     * Set-Cookie header, which is unobservable under the CLI SAPI.
+     *
+     * @return Language
+     */
+    private function createCookieSpy()
+    {
+        return new class extends Language {
+            /** @var int */
+            public $cookieWrites = 0;
+
+            public function __construct()
+            {
+                parent::__construct("english-utf-8", __DIR__ . '/languages/');
+            }
+
+            protected function writeCookie($strLang)
+            {
+                $this->cookieWrites++;
+            }
+        };
+    }
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/LanguageTest.php
+++ b/tests/LanguageTest.php
@@ -4,6 +4,7 @@ namespace Bili\Tests;
 
 use Bili\Language;
 use Bili\LanguageCollection;
+use Bili\Tests\Support\CookieSpy;
 use PHPUnit\Framework\TestCase;
 
 class LanguageTest extends TestCase
@@ -143,17 +144,32 @@ class LanguageTest extends TestCase
     }
 
     /**
-     * The default ($blnPersist = true) still writes the language cookie.
+     * The default ($blnPersist = true) writes the language cookie, scoped to the
+     * root path with a 30-day expiry and the HttpOnly flag.
      *
      * @return void
      */
     public function testSetLangPersistWritesCookie(): void
     {
-        $_SESSION = [];
-        $spy = $this->createCookieSpy();
-        $spy->setLang(self::NL);
+        Language::getInstance()->setLang(self::EN);
+        CookieSpy::reset();
 
-        $this->assertSame(1, $spy->cookieWrites);
+        Language::getInstance()->setLang(self::NL);
+
+        $arrCalls = CookieSpy::calls();
+        $this->assertCount(1, $arrCalls);
+
+        [$strName, $strValue, $intExpires, $strPath, $strDomain, $blnSecure, $blnHttpOnly] = $arrCalls[0];
+        $this->assertSame('language', $strName);
+        $this->assertSame(self::NL, $strValue);
+        $this->assertSame('/', $strPath);
+        $this->assertSame('', $strDomain);
+        $this->assertFalse($blnSecure);
+        $this->assertTrue($blnHttpOnly);
+
+        //*** Bracket the expiry rather than pin it, since time() advances.
+        $this->assertGreaterThan(time() + 60 * 60 * 24 * 29, $intExpires);
+        $this->assertLessThanOrEqual(time() + 60 * 60 * 24 * 30, $intExpires);
     }
 
     /**
@@ -163,42 +179,83 @@ class LanguageTest extends TestCase
      */
     public function testSetLangNoPersistDoesNotWriteCookie(): void
     {
-        $_SESSION = [];
-        $spy = $this->createCookieSpy();
-        $spy->setLang(self::NL, false);
+        Language::getInstance()->setLang(self::EN);
+        CookieSpy::reset();
 
-        $this->assertSame(0, $spy->cookieWrites);
+        Language::getInstance()->setLang(self::NL, false);
+
+        $this->assertSame([], CookieSpy::calls());
     }
 
     /**
-     * A Language subclass that records cookie writes instead of sending a real
-     * Set-Cookie header, which is unobservable under the CLI SAPI.
+     * An unknown language is never persisted, so an unvalidated Accept-Language
+     * value cannot poison the stored choice.
      *
-     * @return Language
+     * @return void
      */
-    private function createCookieSpy()
+    public function testSetLangUnknownLanguageIsNotPersisted(): void
     {
-        return new class extends Language {
-            /** @var int */
-            public $cookieWrites = 0;
+        Language::getInstance()->setLang(self::EN);
+        $_SESSION = [];
+        CookieSpy::reset();
 
-            public function __construct()
-            {
-                parent::__construct("english-utf-8", __DIR__ . '/languages/');
-            }
+        $this->assertFalse(Language::getInstance()->setLang('does-not-exist'));
 
-            protected function writeCookie($strLang)
-            {
-                $this->cookieWrites++;
-            }
-        };
+        $this->assertArrayNotHasKey('language', $_SESSION);
+        $this->assertSame([], CookieSpy::calls());
+        $this->assertSame(self::EN, Language::getInstance()->getActiveLang());
+    }
+
+    /**
+     * With $blnPersist = false a stored session language survives untouched.
+     * A stateless call must not flip the visitor's saved choice.
+     *
+     * @return void
+     */
+    public function testSetLangNoPersistLeavesStoredSessionLanguageIntact(): void
+    {
+        Language::getInstance()->setLang(self::EN);
+        $_SESSION['language'] = self::EN;
+
+        Language::getInstance()->setLang(self::NL, false);
+
+        $this->assertSame(self::EN, $_SESSION['language']);
+        $this->assertSame(self::NL, Language::getInstance()->getActiveLang());
+    }
+
+    /**
+     * setLang() reports whether the language file was actually loaded.
+     * False means unchanged or unknown.
+     *
+     * @return void
+     */
+    public function testSetLangReturnsWhetherTheFileWasLoaded(): void
+    {
+        $objLanguage = Language::getInstance();
+
+        //*** A fresh instance already holds the default, so nothing is reloaded.
+        $this->assertFalse($objLanguage->setLang(self::EN));
+
+        $this->assertTrue($objLanguage->setLang(self::NL));
+        $this->assertTrue($objLanguage->setLang(self::EN, false));
+        $this->assertFalse($objLanguage->setLang('does-not-exist'));
     }
 
     public function setUp(): void
     {
         parent::setUp();
         setlocale(LC_ALL, 'en_US.UTF-8');
+        Language::setUseSecureCookie(false);
         $objLanguage = Language::singleton("english-utf-8", __DIR__ . '/languages/');
         $objLanguage->setLocale();
+    }
+
+    public function tearDown(): void
+    {
+        CookieSpy::reset();
+        $_SESSION = [];
+        $_COOKIE = [];
+
+        parent::tearDown();
     }
 }

--- a/tests/Support/CookieSpy.php
+++ b/tests/Support/CookieSpy.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Bili\Tests\Support;
+
+/**
+ * Records the arguments of every setcookie() call made from the Bili namespace.
+ * Backs the namespaced shim in setcookie.php.
+ *
+ * @see \Bili\setcookie()
+ */
+class CookieSpy
+{
+    /** @var array<int, array<int, mixed>> */
+    private static $calls = array();
+
+    /**
+     * Stores one intercepted setcookie() argument list.
+     *
+     * @param array<int, mixed> $arrArguments
+     * @return void
+     */
+    public static function record(array $arrArguments)
+    {
+        self::$calls[] = $arrArguments;
+    }
+
+    /**
+     * Returns every intercepted call, in invocation order.
+     *
+     * @return array<int, array<int, mixed>>
+     */
+    public static function calls()
+    {
+        return self::$calls;
+    }
+
+    /**
+     * Discards recorded calls so each test starts from a clean slate.
+     *
+     * @return void
+     */
+    public static function reset()
+    {
+        self::$calls = array();
+    }
+}

--- a/tests/Support/setcookie.php
+++ b/tests/Support/setcookie.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bili;
+
+use Bili\Tests\Support\CookieSpy;
+
+/**
+ * Intercepts setcookie() for Bili classes so tests can assert its real arguments.
+ * PHP resolves unqualified calls here before the global function.
+ * headers_list() stays empty under the CLI SAPI.
+ *
+ * @param string $name
+ * @param string $value
+ * @param int $expires
+ * @param string $path
+ * @param string $domain
+ * @param bool $secure
+ * @param bool $httponly
+ * @return bool
+ */
+function setcookie(
+    $name,
+    $value = "",
+    $expires = 0,
+    $path = "",
+    $domain = "",
+    $secure = false,
+    $httponly = false
+) {
+    CookieSpy::record(array($name, $value, $expires, $path, $domain, $secure, $httponly));
+
+    return true;
+}


### PR DESCRIPTION
## Summary

`Language::setLang()` gains an optional second argument,
`$blnPersist` (default `true`). Passing `false` loads the language
file in-process only, without writing the `language` cookie or
`$_SESSION['language']`.

## Motivation and Context

REST APIs resolve language statelessly from the `Accept-Language`
header, but `setLang()` unconditionally wrote a 30-day cookie and a
session value. That cookie then replayed on every subsequent request
from the same client, so a single endpoint's `?language=` choice
leaked across the whole API. The Celery web API needs a way to load a
language in-process without any cookie or session side effects.

The default `true` preserves today's behavior for every existing
caller; only callers that pass `false` opt into the stateless path.
The cookie write is extracted into a `protected writeCookie()` method
so stateless callers can bypass it (and so it is observable in tests,
since the CLI SAPI sends no real headers).

closes #29

## How Has This Been Tested

- Five new unit tests in `LanguageTest` cover the three acceptance
  cases: no-persist writes neither cookie nor session but still loads
  the language file; the default still writes both.
- Full suite green: 251 tests, 854 assertions.
- `phpstan analyse` (level 6, `classes/`) reports no errors.

## Types of Changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.